### PR TITLE
Fix typo in seed data

### DIFF
--- a/database/seed/products.json
+++ b/database/seed/products.json
@@ -309,7 +309,7 @@
   },
   {
     "_id": { "$oid":"626aebdefc13ae081800060c" },
-    "productName": "Almon Paste, 8 oz",
+    "productName": "Almond Paste, 8 oz",
     "description": "",
     "brand": "Solo",
     "category": "baking supplies",


### PR DESCRIPTION
We discovered at the last showcase that our seed data had a typo for 'Almond Paste, 8 oz' as 'Almon Paste, 8 oz'. This is fixed here in the database seed, so it shouldn't show up again.