### PR TITLE
Convert product-list client to use the grouped categories

### DIFF
--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -245,7 +245,7 @@ describe('Product already in shopping list add button', () => {
 
   // Product already in shopping list
   it('should click the add button, then click the button to go to the shopping list page', () => {
-    const testNewProduct: Product = {
+    const newTestProduct: Product = {
       _id: 'testID',
       productName: 'Frog Legs',
       brand: 'Marsh  Inc.',
@@ -260,26 +260,16 @@ describe('Product already in shopping list add button', () => {
       threshold: 4
     };
 
-    //First, add a new product to the product list (so we know it's not already in the shopping list)
-    cy.visit('/products/new');
-
-    page.getAddProductFormField('productName').type(testNewProduct.productName);
-    page.getAddProductFormField('brand').type(testNewProduct.brand);
-    page.selectMatSelectValue(cy.get('[formControlName=store]'), testNewProduct.store);
-    page.getAddProductFormField('location').type(testNewProduct.location);
-    page.selectMatSelectValue(cy.get('[formControlName=category]'), testNewProduct.category);
-
-    page.addProductSubmitButton().click();
-
+    page.addNewProductToDatabase(newTestProduct);
     page.navigateTo();
 
-    cy.get('#product-name-input').type(testNewProduct.productName);
+    cy.get('#product-name-input').type(newTestProduct.productName);
 
     page.getFilteredProductListItems().first().within(($product) => {
       cy.get('[data-test=addToShoppinglistButton]').click();
     });
     //Should open the add to Shopping List Dialog Here
-    cy.get('[data-test=addToShoppingListDialogTitle]').should('contain.text', testNewProduct.productName);
+    cy.get('[data-test=addToShoppingListDialogTitle]').should('contain.text', newTestProduct.productName);
     page.enterShoppingListCount('1');
     page.clickDialogAddShoppingButton();
     cy.get('.mat-simple-snack-bar-content')
@@ -289,7 +279,7 @@ describe('Product already in shopping list add button', () => {
     page.getFilteredProductListItems().first().within(($product) => {
       cy.get('[data-test=addToShoppinglistButton]').click();
     });
-    cy.get('[data-test=productAlreadyInShoppingListDialogTitle]').should('contain.text', testNewProduct.productName);
+    cy.get('[data-test=productAlreadyInShoppingListDialogTitle]').should('contain.text', newTestProduct.productName);
     page.clickDialogGoToShoppingButton();
     page.getUrl().should('be.equal', 'http://localhost:4200/shoppinglist#');
   });

--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -213,7 +213,7 @@ describe ('Add Product to Pantry List', () => {
     page.enterNotes('This is a test');
     page.enterPantryQuantity('20');
     page.clickDialogAddButton();
-    cy.get('.mat-simple-snack-bar-content').should('contain.text', '20 Whole Milk, 1/2 gal successfully added to your pantry.');
+    cy.get('.mat-simple-snack-bar-content').should('be.visible').should('contain.text', '20 Whole Milk, 1/2 gal successfully added to your pantry.');
   });
 });
 
@@ -280,7 +280,7 @@ describe('Product already in shopping list add button', () => {
     });
     //Should open the add to Shopping List Dialog Here
     cy.get('[data-test=addToShoppingListDialogTitle]').should('contain.text', testNewProduct.productName);
-    page.enterCount(1);
+    page.enterShoppingListCount('1');
     page.clickDialogAddShoppingButton();
     cy.get('.mat-simple-snack-bar-content')
     .should('contain.text', 'successfully added to your Shopping List.');

--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -60,7 +60,7 @@ describe ('Product List', () => {
     page.selectCategory('miscellaneous');
 
     // Some of the products should be listed
-    page.getFilteredProductListItems().should('exist');
+    page.getFilteredProductListItems().should('be.visible');
 
     // All of the product list items that show should have the store we are looking for
     page.getFilteredProductListItems().each($product => {
@@ -220,7 +220,6 @@ describe ('Add Product to Shopping List', () => {
 
   it('should enter the count of a shoppinglist item then click the button', () => {
     page.clickExpansionAddShoppingButton('toiletries');
-    cy.wait(600);
     page.enterCount(1);
     page.clickDialogAddShoppingButton();
     cy.get('.mat-simple-snack-bar-content')

--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -243,6 +243,7 @@ describe('Product already in shopping list add button', () => {
     page.clickExpansionAddShoppingButton('baking supplies');
     cy.wait(1000);
     page.clickDialogGoToShoppingButton();
+    cy.wait(1000);
     page.getUrl().should('be.equal', 'http://localhost:4200/shoppinglist#');
   });
 

--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -87,13 +87,13 @@ describe ('Product List Expansion Panels', () => {
 
   it('Should check that expansion panels have the correct titles and items by categories', () => {
 
-    page.getExpansionTitleByCategory('baking supplies').should('have.text', ' baking supplies ');
+    page.getExpansionTitleByCategory('baking supplies').should('have.text', ' baking supplies (3) ');
 
     page.getExpansionItemsByCategory('baking supplies').each($product => {
       cy.wrap($product).find('.product-list-category').should('have.text', ' baking supplies ');
     });
 
-    page.getExpansionTitleByCategory('miscellaneous').should('have.text', ' miscellaneous ');
+    page.getExpansionTitleByCategory('miscellaneous').should('have.text', ' miscellaneous (1) ');
 
     page.getExpansionItemsByCategory('miscellaneous').each($product => {
       cy.wrap($product).find('.product-list-category').should('have.text', ' miscellaneous ');
@@ -206,7 +206,7 @@ describe ('Add Product to Pantry List', () => {
     page.clickExpansionAddButton('dairy');
     page.enterNotes('This is a test');
     page.clickDialogAddButton();
-    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'Whole Milk, 1/2 gal successfully added to your pantry.');
+    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'successfully added to your pantry.');
   });
 
 });
@@ -221,10 +221,11 @@ describe ('Add Product to Shopping List', () => {
 
   it('should enter the count of a shoppinglist item then click the button', () => {
     page.clickExpansionAddShoppingButton('toiletries');
+    cy.wait(600);
     page.enterCount('1');
     page.clickDialogAddShoppingButton();
     cy.get('.mat-simple-snack-bar-content')
-    .should('contain.text', 'Citrus Organic Hair Rinse, 8 fl oz x1 successfully added to your Shopping List.');
+    .should('contain.text', 'successfully added to your Shopping List.');
   });
 
 });
@@ -240,6 +241,7 @@ describe('Product already in shopping list add button', () => {
   // Product already in shopping list
   it('should click the add button, then click the button to go to the shopping list page', () => {
     page.clickExpansionAddShoppingButton('baking supplies');
+    cy.wait(1000);
     page.clickDialogGoToShoppingButton();
     page.getUrl().should('be.equal', 'http://localhost:4200/shoppinglist#');
   });
@@ -257,7 +259,7 @@ describe('Delete from Product List', () => {
   it('should click the delete button on a product and confirm delete', () => {
     page.clickExpansionDeleteButton('staples');
     page.clickDialogDeleteButton();
-    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'Chicken Instant Buillion Cubes, 92 g successfully deleted.');
+    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'successfully deleted.');
   });
 
   it('should remove instances from the pantry and the shopping list.', () => {

--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -248,7 +248,7 @@ describe('Product already in shopping list add button', () => {
       lifespan: 4,
       location: 'Aisle 1',
       notes: 'For testing only',
-      store: 'Pom de Terre',
+      store: 'Pomme de Terre',
       tags: [],
       threshold: 4
     };
@@ -258,7 +258,7 @@ describe('Product already in shopping list add button', () => {
 
     page.getAddProductFormField('productName').type(testNewProduct.productName);
     page.getAddProductFormField('brand').type(testNewProduct.brand);
-    page.getAddProductFormField('store').type(testNewProduct.store);
+    page.selectMatSelectValue(cy.get('[formControlName=store]'), testNewProduct.store);
     page.getAddProductFormField('location').type(testNewProduct.location);
     page.selectMatSelectValue(cy.get('[formControlName=category]'), testNewProduct.category);
 

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -1,4 +1,5 @@
 import { ProductCategory } from 'src/app/products/product';
+import { Product } from 'src/app/products/product';
 
 export class ProductListPage {
   navigateTo() {
@@ -150,5 +151,17 @@ export class ProductListPage {
 
   addProductSubmitButton() {
     return cy.get('[data-test="confirmProductButton"]');
+  }
+
+  addNewProductToDatabase(product: Product) {
+    cy.visit('/products/new');
+
+    this.getAddProductFormField('productName').type(product.productName);
+    this.getAddProductFormField('brand').type(product.brand);
+    this.selectMatSelectValue(cy.get('[formControlName=store]'), product.store);
+    this.getAddProductFormField('location').type(product.location);
+    this.selectMatSelectValue(cy.get('[formControlName=category]'), product.category);
+
+    return this.addProductSubmitButton().click();
   }
 }

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -117,7 +117,7 @@ export class ProductListPage {
   }
 
   enterPantryQuantity(quantity: string) {
-    return cy.get('[data-test=pantryQuantityInput]').type(quantity);
+    return cy.get('[data-test=pantryQuantityInput]').clear().type(quantity);
   }
 
   enterShoppingListCount(count: string) {

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -26,15 +26,15 @@ export class ProductListPage {
   }
 
   /**
-   * Selects a category to filter in the "Category" selector.
-   *
-   * @param value The category *value* to select, this is what's found in the mat-option "value" attribute.
-   */
+    * Selects a category to filter in the "Category" selector.
+    *
+    * @param value The category *value* to select, this is what's found in the mat-option "value" attribute.
+  */
   selectCategory(value: ProductCategory) {
     // Find and click the drop down
-    return cy.get('[data-test=productCategorySelect]').click({ force: true})
+    return cy.get('[data-test=productCategorySelect]').click()
       // Select and click the desired value from the resulting menu
-      .get(`mat-option[ng-reflect-value="${value}"]`).should('exist').click({ force: true});
+      .get(`mat-option`).contains(value, { matchCase: false }).click({ force: true });
   }
 
   /**
@@ -46,7 +46,7 @@ export class ProductListPage {
     // Find and click the drop down
     return cy.get('[data-test=productStoreSelect]').click()
       // Select and click the desired value from the resulting menu
-      .get(`mat-option[ng-reflect-value="${value}"]`).click();
+      .get(`mat-option`).contains(value).click({ force: true });
   }
 
   addProductButton() {

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -32,9 +32,9 @@ export class ProductListPage {
    */
   selectCategory(value: ProductCategory) {
     // Find and click the drop down
-    return cy.get('[data-test=productCategorySelect]').click()
-             // Select and click the desired value from the resulting menu
-             .get(`mat-option[ng-reflect-value="${value}"]`).should('be.visible').click();
+    return cy.get('[data-test=productCategorySelect]').click({ force: true})
+      // Select and click the desired value from the resulting menu
+      .get(`mat-option[ng-reflect-value="${value}"]`).should('exist').click({ force: true});
   }
 
   /**

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -34,7 +34,7 @@ export class ProductListPage {
     // Find and click the drop down
     return cy.get('[data-test=productCategorySelect]').click()
              // Select and click the desired value from the resulting menu
-             .get(`mat-option[ng-reflect-value="${value}"]`).click();
+             .get(`mat-option[ng-reflect-value="${value}"]`).should('be.visible').click();
   }
 
   /**
@@ -122,7 +122,7 @@ export class ProductListPage {
   }
 
   enterCount(count: number) {
-    return cy.get('[data-test=countInput]').type(`${count}`);
+    return cy.get('[data-test=countInput]').should('be.visible').type(`${count}`);
   }
 
   clickDialogAddButton() {

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -103,9 +103,9 @@ export class ProductListPage {
   }
 
   clickExpansionAddShoppingButton(category: string) {
-    return cy.get('.' + category.replace(' ', '-') + '-expansion-panel')
+    return cy.get(`.${category.replace(' ', '-')}-expansion-panel`)
       .click()
-      .get('.' + category.replace(' ', '-') + '-nav-list')
+      .get(`.${category.replace(' ', '-')}-nav-list`)
       .first()
       .within(($product) => {
         cy.get('[data-test=addToShoppinglistButton]')
@@ -121,8 +121,8 @@ export class ProductListPage {
     return cy.get('[data-test=notesInput]').type(notes);
   }
 
-  enterCount(notes: string) {
-    return cy.get('[data-test=countInput]').type(notes);
+  enterCount(count: number) {
+    return cy.get('[data-test=countInput]').type(`${count}`);
   }
 
   clickDialogAddButton() {
@@ -130,14 +130,26 @@ export class ProductListPage {
   }
 
   clickDialogAddShoppingButton() {
-    return cy.get('[data-test=confirmAddProductToShoppinglistButton]').click();
+    return cy.get('[data-test=confirmAddProductToShoppinglistButton]').click({ force: true });
   }
 
   clickDialogGoToShoppingButton() {
-    return cy.get('[data-test=goToShoppingListButton]').click();
+    return cy.get('[data-test=goToShoppingListButton]').click({ force: true });
   }
 
   clickDialogDeleteButton() {
     return cy.get('[data-test=dialogDelete]').click();
+  }
+
+  getAddProductFormField(fieldName: string) {
+    return cy.get(`mat-form-field [formControlName=${fieldName}]`);
+  }
+
+  selectMatSelectValue(select: Cypress.Chainable, value: string) {
+    return select.click().get(`mat-option[value="${value}"]`).click();
+  }
+
+  addProductSubmitButton() {
+    return cy.get('[data-test="confirmProductButton"]');
   }
 }

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -25,11 +25,6 @@ export class ProductListPage {
     return cy.get('.' + category.replace(' ', '-') + '-expansion-panel .' + category.replace(' ', '-') + '-nav-list');
   }
 
-  /**
-    * Selects a category to filter in the "Category" selector.
-    *
-    * @param value The category *value* to select, this is what's found in the mat-option "value" attribute.
-  */
   selectCategory(value: ProductCategory) {
     // Find and click the drop down
     return cy.get('[data-test=productCategorySelect]').click()

--- a/client/src/app/products/product-list/add-product-to-shoppinglist/add-product-to-shoppinglist.component.html
+++ b/client/src/app/products/product-list/add-product-to-shoppinglist/add-product-to-shoppinglist.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>Add {{data.productName | titlecase}} to your Shopping List</h2>
+<h2 mat-dialog-title data-test="addToShoppingListDialogTitle">Add {{data.productName | titlecase}} to your Shopping List</h2>
 
 <mat-dialog-content [formGroup]="addToShoppinglistForm">
   <mat-form-field appearance="fill">

--- a/client/src/app/products/product-list/product-exists-in-shoppinglist-dialog/product-exists-in-shoppinglist-dialog.component.html
+++ b/client/src/app/products/product-list/product-exists-in-shoppinglist-dialog/product-exists-in-shoppinglist-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>{{data.productName | titlecase}} from {{data.store | titlecase}} is already in your Shopping List</h2>
+<h2 mat-dialog-title data-test="productAlreadyInShoppingListDialogTitle">{{data.productName | titlecase}} from {{data.store | titlecase}} is already in your Shopping List</h2>
 
 <mat-dialog-content>
   <h2>Go to your Shopping List?</h2>

--- a/client/src/app/products/product-list/product-list.component.html
+++ b/client/src/app/products/product-list/product-list.component.html
@@ -27,7 +27,7 @@
         <div fxLayout="row wrap" fxLayoutGap="15px">
           <mat-form-field class="input-field">
             <mat-label>Store</mat-label>
-            <mat-select (selectionChange)="getProductsFromServer()" [(ngModel)]="productStore"
+            <mat-select (selectionChange)="getGroupedProductsFromServer()" [(ngModel)]="productStore"
               data-test="productStoreSelect">
               <mat-option>--</mat-option>
               <mat-option *ngFor="let store of storesList" [value]="store">{{store | titlecase }}
@@ -38,7 +38,7 @@
 
           <mat-form-field class="input-field">
             <mat-label>Category</mat-label>
-            <mat-select (selectionChange)="getProductsFromServer()" [(ngModel)]="productCategory"
+            <mat-select (selectionChange)="getGroupedProductsFromServer()" [(ngModel)]="productCategory"
               data-test="productCategorySelect">
               <mat-option>--</mat-option>
               <mat-option *ngFor="let category of categoriesList" [value]="category">{{category | titlecase }}
@@ -60,7 +60,7 @@
 
 <!-- Products displayed on filter search -->
 <div fxLayout="row">
-  <div fxFlex fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10" *ngIf="serverFilteredProducts; else productsError"
+  <div fxFlex fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10" *ngIf="groupedProducts; else productsError"
     style="width: 90%;">
     <mat-card *ngIf="activeFilters" class="conditional-product-list">
       <mat-card-content>
@@ -106,18 +106,18 @@
       <mat-card-content>
         <!--Display All Product Categories as Dropdowns-->
         <mat-accordion>
-          <mat-expansion-panel *ngFor="let productCategory of (this.categoryNameMap | keyvalue)"
-            [ngClass]="productCategory.key.replace(' ', '-') + '-expansion-panel'">
+          <mat-expansion-panel *ngFor="let categoryGroup of this.groupedProducts"
+            [ngClass]="categoryGroup.category.replace(' ', '-') + '-expansion-panel'">
             <mat-expansion-panel-header>
-              <mat-panel-title [ngClass]="productCategory.key.replace(' ', '-') + '-panel-title'" style="text-transform: capitalize">
-                {{ productCategory.key }}
+              <mat-panel-title [ngClass]="categoryGroup.category.replace(' ', '-') + '-panel-title'" style="text-transform: capitalize">
+                {{ categoryGroup.category }} ({{ categoryGroup.count}})
               </mat-panel-title>
             </mat-expansion-panel-header>
 
             <!--Display All the Products in the Category-->
             <mat-action-list>
-              <mat-list-item [ngClass]="productCategory.key.replace(' ', '-') + '-nav-list'"
-                *ngFor="let product of productCategory.value">
+              <mat-list-item [ngClass]="categoryGroup.category.replace(' ', '-') + '-nav-list'"
+                *ngFor="let product of categoryGroup.products">
                 <!-- Product Info wrapped by link to product card -->
                 <div matLine [routerLink]="['/products', product._id]">
                   <p matLine class="product-list-brand" style="color:purple"><b> {{product.brand}} </b></p>

--- a/client/src/app/products/product-list/product-list.component.spec.ts
+++ b/client/src/app/products/product-list/product-list.component.spec.ts
@@ -101,25 +101,6 @@ describe('ProductListComponent', () => {
     productList.getProductsFromServer();
     expect(productList.filteredProducts.some((product: Product) => product.productName === 'banana')).toBe(true);
   });
-
-  it('should fill in categoryNameMap with brand key to array of product objects value', () => {
-    expect(productList.categoryNameMap.get('produce'))
-    .toEqual([{
-      _id: 'banana_id',
-      productName: 'banana',
-      description: '',
-      brand: 'Dole',
-      category: 'produce',
-      store: 'Walmart',
-      location: 'c 1',
-      notes: '',
-      tags: [],
-      lifespan: 0,
-      threshold: 0,
-      image: ''
-    }]);
-  });
-
 });
 
 

--- a/client/src/app/products/product-list/product-list.component.ts
+++ b/client/src/app/products/product-list/product-list.component.ts
@@ -112,7 +112,6 @@ export class ProductListComponent implements OnInit, OnDestroy {
     }
   }
 
-
   /**
    * @deprecated Method no longer in use, use the getGroupedProductsFromServer() instead.
    */
@@ -129,7 +128,6 @@ export class ProductListComponent implements OnInit, OnDestroy {
         this.activeFilters = false;
       }
       this.serverFilteredProducts = returnedProducts;
-      //this.initializeCategoryMap();
       this.updateFilter();
     }, err => {
       console.log(err);
@@ -141,9 +139,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
     for (let givenCategory of this.categoriesList) {
       this.categoryNameMap.set(givenCategory,
         this.productService.filterProducts(this.serverFilteredProducts, { category: givenCategory }));
-
     }
-    console.log(this.categoryNameMap);
   }
 
 

--- a/client/src/app/products/product-list/product-list.component.ts
+++ b/client/src/app/products/product-list/product-list.component.ts
@@ -93,10 +93,29 @@ export class ProductListComponent implements OnInit, OnDestroy {
         this.activeFilters = false;
       }
       this.groupedProducts = returnedProducts;
+      this.extractAllProducts();
       this.updateFilter();
-    });
+    }, err => {
+      console.error(err);
+    }
+    );
   }
 
+  /**
+   * @deprecated This method exists as a transition between the usage of
+   * getGroupedProducts() and getProductsFromServer().
+   */
+  extractAllProducts(): void {
+    this.serverFilteredProducts = [];
+    for (let category of this.groupedProducts) {
+      this.serverFilteredProducts = this.serverFilteredProducts.concat(category.products);
+    }
+  }
+
+
+  /**
+   * @deprecated Method no longer in use, use the getGroupedProductsFromServer() instead.
+   */
   getProductsFromServer(): void {
     this.unsub();
     this.getProductsSub = this.productService.getProducts({
@@ -110,7 +129,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
         this.activeFilters = false;
       }
       this.serverFilteredProducts = returnedProducts;
-      this.initializeCategoryMap();
+      //this.initializeCategoryMap();
       this.updateFilter();
     }, err => {
       console.log(err);
@@ -176,7 +195,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
     });
   }
 
-    // Pops up a dialog to add a product to the shoppinglist
+  // Pops up a dialog to add a product to the shoppinglist
   /* istanbul ignore next */
   openShoppinglistAddDialog(givenProduct: Product) {
     const dialogRef = this.dialog.open(AddProductToShoppinglistComponent, { data: givenProduct });
@@ -195,12 +214,12 @@ export class ProductListComponent implements OnInit, OnDestroy {
   }
 
   // Pops up a dialog for increasing the count of an already existing product in shopping list
-    /* istanbul ignore next */
+  /* istanbul ignore next */
   openShoppinglistExistsDialog(givenProduct: Product) {
     this.dialog.open(ProductExistsInShoppinglistDialogComponent, { data: givenProduct });
   }
 
-    /* istanbul ignore next */
+  /* istanbul ignore next */
   showDialogByProductInShoppingList(givenProduct): void {
     this.shoppinglistService.productInShoppinglist(givenProduct._id).subscribe(
       data => {

--- a/client/src/app/products/product-list/product-list.component.ts
+++ b/client/src/app/products/product-list/product-list.component.ts
@@ -157,7 +157,6 @@ export class ProductListComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.getGroupedProductsFromServer();
-    //this.getProductsFromServer();
   }
 
   ngOnDestroy(): void {

--- a/client/src/app/products/product-list/product-list.component.ts
+++ b/client/src/app/products/product-list/product-list.component.ts
@@ -13,6 +13,7 @@ import { AddProductToShoppinglistComponent } from './add-product-to-shoppinglist
 // eslint-disable-next-line max-len
 import { ProductExistsInShoppinglistDialogComponent } from './product-exists-in-shoppinglist-dialog/product-exists-in-shoppinglist-dialog.component';
 import { ShoppinglistService } from 'src/app/shoppinglist/shoppinglist.service';
+import { CategorySortItem } from '../CategorySortItem';
 
 
 @Component({
@@ -29,6 +30,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
 
   public serverFilteredProducts: Product[];
   public filteredProducts: Product[];
+  public groupedProducts: CategorySortItem[];
 
   public name: string;
   public productBrand: string;
@@ -37,6 +39,7 @@ export class ProductListComponent implements OnInit, OnDestroy {
   public productLimit: number;
   getProductsSub: Subscription;
   getUnfilteredProductsSub: Subscription;
+  getGroupedProductsSub: Subscription;
 
   // Boolean for if there are active filters
   public activeFilters: boolean;
@@ -73,6 +76,26 @@ export class ProductListComponent implements OnInit, OnDestroy {
 
   constructor(private productService: ProductService, private snackBar: MatSnackBar, private pantryService: PantryService,
     private shoppinglistService: ShoppinglistService, private dialog: MatDialog) { }
+
+
+  getGroupedProductsFromServer(): void {
+    this.unsub();
+    this.getGroupedProductsSub = this.productService.getGroupedProducts(
+      {
+        category: this.productCategory,
+        store: this.productStore
+      }
+    ).subscribe(returnedProducts => {
+      if (this.productCategory || this.productStore) {
+        this.activeFilters = true;
+      }
+      else {
+        this.activeFilters = false;
+      }
+      this.groupedProducts = returnedProducts;
+      this.updateFilter();
+    });
+  }
 
   getProductsFromServer(): void {
     this.unsub();
@@ -118,7 +141,8 @@ export class ProductListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.getProductsFromServer();
+    this.getGroupedProductsFromServer();
+    //this.getProductsFromServer();
   }
 
   ngOnDestroy(): void {
@@ -128,6 +152,9 @@ export class ProductListComponent implements OnInit, OnDestroy {
   unsub(): void {
     if (this.getProductsSub) {
       this.getProductsSub.unsubscribe();
+    }
+    if (this.getGroupedProductsSub) {
+      this.getGroupedProductsSub.unsubscribe();
     }
   }
 

--- a/client/src/app/products/product.service.spec.ts
+++ b/client/src/app/products/product.service.spec.ts
@@ -3,6 +3,7 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { CategorySortItem } from './CategorySortItem';
 import { Product } from './product';
 import { ProductService } from './product.service';
 
@@ -53,6 +54,65 @@ describe('ProductService', () => {
     }
   ];
 
+  const testGroupedProducts: CategorySortItem[] = [
+    {
+      category: 'produce',
+      count: 1,
+      products: [{
+        _id: 'banana_id',
+        productName: 'banana',
+        description: '',
+        brand: 'Dole',
+        category: 'produce',
+        store: 'Walmart',
+        location: '',
+        notes: '',
+        tags: [],
+        lifespan: 0,
+        threshold: 0,
+        image: ''
+      }]
+    },
+    {
+      category: 'dairy',
+      count: 1,
+      products: [{
+        _id: 'milk_id',
+      productName: 'Whole Milk',
+      description: '',
+      brand: 'Land O Lakes',
+      category: 'dairy',
+      store: 'SuperValu',
+      location: '',
+      notes: '',
+      tags: [],
+      lifespan: 0,
+      threshold: 0,
+      image: ''
+      }]
+    },
+    {
+      category: 'baked goods',
+      count: 1,
+      products: [
+        {
+          _id: 'bread_id',
+          productName: 'Wheat Bread',
+          description: '',
+          brand: 'Country Hearth',
+          category: 'baked goods',
+          store: 'Walmart',
+          location: '',
+          notes: '',
+          tags: [],
+          lifespan: 0,
+          threshold: 0,
+          image: ''
+        }
+      ]
+    }
+  ];
+
   let productService: ProductService;
   let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
@@ -93,6 +153,28 @@ describe('ProductService', () => {
     // triggers the subscribe above, which leads to that check
     // actually being performed.
     req.flush(testProducts);
+  });
+
+  it('getGroupedProducts calls api/products/group with parameter \'category\'', () => {
+    productService.getGroupedProducts({ category: 'produce'}).subscribe(
+      products => expect(products).toBe(testGroupedProducts)
+    );
+
+    const req = httpTestingController.expectOne(
+      (request) => request.url.startsWith(`${productService.productUrl}/group`) && request.params.has('category')
+    );
+    expect(req.request.method).toEqual('GET');
+  });
+
+  it('getGroupedProducts calls api/products/group with parameter \'store\'', () => {
+    productService.getGroupedProducts({ store: 'Walmart'}).subscribe(
+      products => expect(products).toBe(testGroupedProducts)
+    );
+
+    const req = httpTestingController.expectOne(
+      (request) => request.url.startsWith(`${productService.productUrl}/group`) && request.params.has('store')
+    );
+    expect(req.request.method).toEqual('GET');
   });
 
   it('getProducts() calls api/products with filter parameter \'produce\'', () => {

--- a/client/src/app/products/product.service.spec.ts
+++ b/client/src/app/products/product.service.spec.ts
@@ -155,13 +155,13 @@ describe('ProductService', () => {
     req.flush(testProducts);
   });
 
-  it('getGroupedProducts calls api/products/group with parameter \'category\'', () => {
+  it('getGroupedProducts calls api/products-by-category with parameter \'category\'', () => {
     productService.getGroupedProducts({ category: 'produce'}).subscribe(
       products => expect(products).toBe(testGroupedProducts)
     );
 
     const req = httpTestingController.expectOne(
-      (request) => request.url.startsWith(`${productService.productUrl}/group`) && request.params.has('category')
+      (request) => request.url.startsWith(`${productService.productUrl}-by-category`) && request.params.has('category')
     );
     expect(req.request.method).toEqual('GET');
   });
@@ -172,7 +172,7 @@ describe('ProductService', () => {
     );
 
     const req = httpTestingController.expectOne(
-      (request) => request.url.startsWith(`${productService.productUrl}/group`) && request.params.has('store')
+      (request) => request.url.startsWith(`${productService.productUrl}-by-category`) && request.params.has('store')
     );
     expect(req.request.method).toEqual('GET');
   });

--- a/client/src/app/products/product.service.ts
+++ b/client/src/app/products/product.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../environments/environment';
 import { Product, ProductCategory } from './product';
 import { map } from 'rxjs/operators';
 import { CategorySortItem } from './CategorySortItem';
-import { useAnimation } from '@angular/animations';
+
 
 @Injectable()
 export class ProductService {

--- a/client/src/app/products/product.service.ts
+++ b/client/src/app/products/product.service.ts
@@ -6,14 +6,15 @@ import { environment } from '../../environments/environment';
 import { Product, ProductCategory } from './product';
 import { map } from 'rxjs/operators';
 import { CategorySortItem } from './CategorySortItem';
+import { useAnimation } from '@angular/animations';
 
 @Injectable()
 export class ProductService {
   readonly productUrl: string = environment.apiUrl + 'products';
 
-  constructor(private httpClient: HttpClient) {}
+  constructor(private httpClient: HttpClient) { }
 
-  getGroupedProducts(filters?: {category?: ProductCategory; store?: string }): Observable<CategorySortItem[]> {
+  getGroupedProducts(filters?: { category?: ProductCategory; store?: string }): Observable<CategorySortItem[]> {
     let httpParams: HttpParams = new HttpParams();
     if (filters) {
       if (filters.category) {
@@ -22,12 +23,14 @@ export class ProductService {
       if (filters.store) {
         httpParams = httpParams.set('store', filters.store);
       }
-      return this.httpClient.get<CategorySortItem[]>(`${this.productUrl}/group`, {
+      return this.httpClient.get<CategorySortItem[]>(`${this.productUrl}-by-category`, {
         params: httpParams,
       });
     }
   }
 
+  /**
+   * @deprecated This method is no longer in use, use getGroupedProducts() instead. */
   getProducts(filters?: { category?: ProductCategory; store?: string }): Observable<Product[]> {
     let httpParams: HttpParams = new HttpParams();
     if (filters) {
@@ -80,7 +83,7 @@ export class ProductService {
 
   addProduct(newProduct: Product): Observable<string> {
     // Send post request to add a new user with the user data as the body.
-    return this.httpClient.post<{id: string}>(this.productUrl, newProduct).pipe(map(res => res.id));
+    return this.httpClient.post<{ id: string }>(this.productUrl, newProduct).pipe(map(res => res.id));
   }
 
   deleteProduct(id: string): Observable<boolean> {

--- a/client/src/app/products/product.service.ts
+++ b/client/src/app/products/product.service.ts
@@ -6,7 +6,6 @@ import { environment } from '../../environments/environment';
 import { Product, ProductCategory } from './product';
 import { map } from 'rxjs/operators';
 import { CategorySortItem } from './CategorySortItem';
-import { filter } from 'lodash';
 
 @Injectable()
 export class ProductService {

--- a/client/src/app/products/product.service.ts
+++ b/client/src/app/products/product.service.ts
@@ -5,12 +5,29 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { Product, ProductCategory } from './product';
 import { map } from 'rxjs/operators';
+import { CategorySortItem } from './CategorySortItem';
+import { filter } from 'lodash';
 
 @Injectable()
 export class ProductService {
   readonly productUrl: string = environment.apiUrl + 'products';
 
   constructor(private httpClient: HttpClient) {}
+
+  getGroupedProducts(filters?: {category?: ProductCategory; store?: string }): Observable<CategorySortItem[]> {
+    let httpParams: HttpParams = new HttpParams();
+    if (filters) {
+      if (filters.category) {
+        httpParams = httpParams.set('category', filters.category);
+      }
+      if (filters.store) {
+        httpParams = httpParams.set('store', filters.store);
+      }
+      return this.httpClient.get<CategorySortItem[]>(`${this.productUrl}/group`, {
+        params: httpParams,
+      });
+    }
+  }
 
   getProducts(filters?: { category?: ProductCategory; store?: string }): Observable<Product[]> {
     let httpParams: HttpParams = new HttpParams();

--- a/client/src/testing/product.service.mock.ts
+++ b/client/src/testing/product.service.mock.ts
@@ -4,6 +4,7 @@
 
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
+import { CategorySortItem } from 'src/app/products/CategorySortItem';
 import { Product, ProductCategory } from '../app/products/product';
 import { ProductService } from '../app/products/product.service';
 
@@ -67,8 +68,30 @@ export class MockProductService extends ProductService {
   }
 
   override getProducts(filters: { category?: ProductCategory; store?: string }): Observable<Product[]> {
-    // Just return the test users regardless of what filters are passed in
+    // Just return the test products regardless of what filters are passed in
     return of(MockProductService.testProducts);
+  }
+
+  override getGroupedProducts(filters?: { category?: ProductCategory; store?: string }): Observable<CategorySortItem[]> {
+    //just return the whole array of products regardless of filter
+    const output: CategorySortItem[] = [{
+      category: 'produce',
+      count: 1,
+      products: [MockProductService.testProducts[0]]
+    },
+    {
+      category: 'dairy',
+      count: 1,
+      products: [MockProductService.testProducts[2]]
+    },
+    {
+      category: 'baked goods',
+      count: 1,
+      products: [MockProductService.testProducts[1]]
+    }
+    ];
+
+    return of(output);
   }
 
   override getProductById(id: string): Observable<Product> {
@@ -81,25 +104,25 @@ export class MockProductService extends ProductService {
       return of(null);
     }
   }
-/*
-  override deleteProduct(id: string): Observable<boolean> {
-    for(let i = 0; i < MockProductService.testProducts.length; i++) {
-      if (id !== MockProductService.testProducts[i]._id) {return new Observable<false>();}
-    }
-    for(let j = 0; j < MockProductService.testProducts.length; j++) {
-      if (id === MockProductService.testProducts[j]._id) { MockProductService.testProducts.splice(j,1);}
+  /*
+    override deleteProduct(id: string): Observable<boolean> {
+      for(let i = 0; i < MockProductService.testProducts.length; i++) {
+        if (id !== MockProductService.testProducts[i]._id) {return new Observable<false>();}
+      }
+      for(let j = 0; j < MockProductService.testProducts.length; j++) {
+        if (id === MockProductService.testProducts[j]._id) { MockProductService.testProducts.splice(j,1);}
 
-  override deleteProduct(id: string): Observable<boolean> {
-    for(let i = 0; i < MockProductService.testProducts.length; i++) {
-      if (id !== MockProductService.testProducts[i]._id) {return new Observable<false>();}
-    }
-    for(let j = 0; j < MockProductService.testProducts.length; j++) {
-      if (id === MockProductService.testProducts[j]._id) { MockProductService.testProducts.splice(j,1);}
+    override deleteProduct(id: string): Observable<boolean> {
+      for(let i = 0; i < MockProductService.testProducts.length; i++) {
+        if (id !== MockProductService.testProducts[i]._id) {return new Observable<false>();}
+      }
+      for(let j = 0; j < MockProductService.testProducts.length; j++) {
+        if (id === MockProductService.testProducts[j]._id) { MockProductService.testProducts.splice(j,1);}
 
+      }
+      return new Observable<true>();
     }
-    return new Observable<true>();
-  }
- */
+   */
   override addProduct(newProduct: Product): Observable<string> {
     return of(MockProductService.testID);
   }

--- a/database/mongoseed.sh
+++ b/database/mongoseed.sh
@@ -3,6 +3,9 @@
 seed_db="${MONGO_DB:-dev}"
 echo Dropping DB $seed_db
 mongo "$seed_db" --eval "db.dropDatabase()"
+mongo "$seed_db" --eval "db.getCollection('products').createIndex({category: 1, store: 1})"
+mongo "$seed_db" --eval "db.getCollection('pantry').createIndex({product: 1})"
+mongo "$seed_db" --eval "db.getCollection('shoppinglist').createIndex({\"products.location\": 1})"
 for file in "$(dirname "$BASH_SOURCE")"/seed/*.json; do
   if [[ -f "$file" ]]; then
     echo Seeding $(basename "$file" ".json") from $file in DB $seed_db

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -67,7 +67,8 @@ public class Server {
     // List products, filtered using query params
     server.get("/api/products", productController::getAllProducts);
 
-    //server.get("/api/products/group", productController::groupProductsByCategory);
+    // List the products grouped by their category
+    server.get("/api/products/group", productController::groupProductsByCategory);
 
     // Get the specified product
     server.get("/api/products/{id}", productController::getProductByID);

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -68,7 +68,7 @@ public class Server {
     server.get("/api/products", productController::getAllProducts);
 
     // List the products grouped by their category
-    server.get("/api/products/group", productController::groupProductsByCategory);
+    server.get("/api/products-by-category", productController::groupProductsByCategory);
 
     // Get the specified product
     server.get("/api/products/{id}", productController::getProductByID);

--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -111,13 +111,12 @@ public class ProductController {
 
   public void groupProductsByCategory(Context ctx) {
     Bson combinedFilter = constructFilter(ctx);
-    Bson sortingOrder = constructSortingOrder(ctx);
 
     ArrayList<CategorySortItem> output = productCollection
         .aggregate(
             Arrays.asList(
                 Aggregates.match(combinedFilter),
-                //Aggregates.sort(sortingOrder),
+                Aggregates.sort(Sorts.ascending("productName")),
                 Aggregates.group("$category",
                     Accumulators.sum("count", 1),
                     Accumulators.addToSet("products", "$$ROOT")),
@@ -126,9 +125,19 @@ public class ProductController {
                         Projections.computed("category", "$_id"),
                         Projections.include("count", "products"),
                         Projections.excludeId())),
-                Aggregates.sort(Sorts.ascending("_id"))),
+                Aggregates.sort(Sorts.ascending("category"))),
             CategorySortItem.class)
         .into(new ArrayList<>());
+
+    // For each product category, this sorts the list of products in that
+    // category by the product name.
+    // It would be nice to figure out how to have Mongo do this internal
+    // sorting for us, but this works for now.
+    output.forEach(categoryEntry -> {
+      categoryEntry.products.sort((first, second) -> {
+        return first.productName.compareTo(second.productName);
+      });
+    });
 
     ctx.json(output);
 
@@ -140,12 +149,6 @@ public class ProductController {
     if (ctx.queryParamMap().containsKey(PRODUCT_NAME_KEY)) {
       filters.add(regex(PRODUCT_NAME_KEY, Pattern.quote(ctx.queryParam(PRODUCT_NAME_KEY)), "i"));
     }
-    /*
-     * if (ctx.queryParamMap().containsKey(DESCRIPTION_KEY)) {
-     * filters.add(regex(DESCRIPTION_KEY,
-     * Pattern.quote(ctx.queryParam(DESCRIPTION_KEY)), "i"));
-     * }
-     */
 
     if (ctx.queryParamMap().containsKey(BRAND_KEY)) {
       filters.add(regex(BRAND_KEY, Pattern.quote(ctx.queryParam(BRAND_KEY)), "i"));

--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -132,7 +132,8 @@ public class ProductController {
                             .append("productName", "$productName")
                             .append("store", "$store")
                             .append("tags", "$tags")
-                            .append("threshold", "$threshold"))),
+                            .append("threshold", "$threshold"))
+                            ),
                 Aggregates.project(
                     Projections.fields(
                         Projections.computed("category", "$_id"),

--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -117,7 +117,7 @@ public class ProductController {
         .aggregate(
             Arrays.asList(
                 Aggregates.match(combinedFilter),
-                Aggregates.sort(sortingOrder),
+                //Aggregates.sort(sortingOrder),
                 Aggregates.group("$category",
                     Accumulators.sum("count", 1),
                     Accumulators.addToSet("products",

--- a/server/src/main/java/umm3601/shoppinglist/ShoppingListController.java
+++ b/server/src/main/java/umm3601/shoppinglist/ShoppingListController.java
@@ -118,27 +118,6 @@ public class ShoppingListController {
     return output;
   }
 
-  public void getAllShoppingListItems(Context ctx) {
-    ArrayList<Document> returnedShoppingListItems = shoppingListCollection
-        .aggregate(
-            Arrays.asList(
-                Aggregates.lookup("products", "product", "_id", "productData"),
-                Aggregates.unwind("$productData"),
-                Aggregates.group("$productData.store", Accumulators.addToSet("products",
-                    new Document("productName", "$productData.productName")
-                        .append("location", "$productData.location")
-                        .append("count", "$count"))),
-                Aggregates.project(Projections.fields(
-                    Projections.computed("store", "$_id"),
-                    Projections.include("products"),
-                    Projections.excludeId())),
-                Aggregates.sort(ascending("store"))),
-            Document.class)
-        .into(new ArrayList<>());
-
-    ctx.json(returnedShoppingListItems);
-  }
-
   /**
    * Checks if the given entry exists with a given id. if no such entry exists
    * returns false. Returns true for one or more entry with a matching


### PR DESCRIPTION
Changed the product-list typescript component to use the server /api/products/group route which groups the products by category on the database, rather than on the client. The previous code still exists, and the new code should replace the old code eventually. 