### PR TITLE
Avoid rebuilding product docs in products by category query

### DIFF
--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -120,19 +120,7 @@ public class ProductController {
                 Aggregates.sort(sortingOrder),
                 Aggregates.group("$category",
                     Accumulators.sum("count", 1),
-                    Accumulators.addToSet("products",
-                        new Document("_id", "$_id")
-                            .append("brand", "$brand")
-                            .append("description", "$description")
-                            .append("image", "$image")
-                            .append("category", "$category")
-                            .append("lifespan", "$lifespan")
-                            .append("location", "$location")
-                            .append("notes", "$notes")
-                            .append("productName", "$productName")
-                            .append("store", "$store")
-                            .append("tags", "$tags")
-                            .append("threshold", "$threshold"))),
+                    Accumulators.addToSet("products", "$$ROOT")),
                 Aggregates.project(
                     Projections.fields(
                         Projections.computed("category", "$_id"),


### PR DESCRIPTION
We were essentially reconstructing every product object in the `groupProductsByCategory()` query in `ProductController.java`, which probably wasn't very efficient and _definitely_ was a maintenance issue since we'd have to remember to update this code every time we modified the `Product` schema.

Some searching turned up the existence of the `$$ROOT` system variable which, in groupings, gives you the entire object. Using that appears to make everything work just fine.