### PR TITLE
Allow adding many copies of an item to the pantry

### DIFF
--- a/client/cypress/integration/product-list.spec.ts
+++ b/client/cypress/integration/product-list.spec.ts
@@ -206,9 +206,16 @@ describe ('Add Product to Pantry List', () => {
     page.clickExpansionAddButton('dairy');
     page.enterNotes('This is a test');
     page.clickDialogAddButton();
-    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'Whole Milk, 1/2 gal successfully added to your pantry.');
+    cy.get('.mat-simple-snack-bar-content').should('contain.text', '1 Whole Milk, 1/2 gal successfully added to your pantry.');
   });
 
+  it('should add several copies of the product to the pantry', () => {
+    page.clickExpansionAddButton('dairy');
+    page.enterNotes('This is a test');
+    page.enterPantryQuantity('20');
+    page.clickDialogAddButton();
+    cy.get('.mat-simple-snack-bar-content').should('contain.text', '20 Whole Milk, 1/2 gal successfully added to your pantry.');
+  });
 });
 
 describe ('Add Product to Shopping List', () => {
@@ -221,7 +228,7 @@ describe ('Add Product to Shopping List', () => {
 
   it('should enter the count of a shoppinglist item then click the button', () => {
     page.clickExpansionAddShoppingButton('toiletries');
-    page.enterCount('1');
+    page.enterShoppingListCount('1');
     page.clickDialogAddShoppingButton();
     cy.get('.mat-simple-snack-bar-content')
     .should('contain.text', 'Citrus Organic Hair Rinse, 8 fl oz x1 successfully added to your Shopping List.');

--- a/client/cypress/support/product-list.po.ts
+++ b/client/cypress/support/product-list.po.ts
@@ -121,8 +121,12 @@ export class ProductListPage {
     return cy.get('[data-test=notesInput]').type(notes);
   }
 
-  enterCount(notes: string) {
-    return cy.get('[data-test=countInput]').type(notes);
+  enterPantryQuantity(quantity: string) {
+    return cy.get('[data-test=pantryQuantityInput]').type(quantity);
+  }
+
+  enterShoppingListCount(count: string) {
+    return cy.get('[data-test=shoppingListCountInput]').type(count);
   }
 
   clickDialogAddButton() {

--- a/client/src/app/products/product-list/add-product-to-pantry/add-product-to-pantry.component.html
+++ b/client/src/app/products/product-list/add-product-to-pantry/add-product-to-pantry.component.html
@@ -4,16 +4,44 @@
   <mat-form-field appearance="fill">
     <mat-label>Date Added to Pantry</mat-label>
     <input matInput [matDatepicker]="picker" formControlName="purchase_date" data-test="date-picker-button"
-                  required>
-                  <mat-hint>DD/MM/YYYY</mat-hint>
-                  <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-                  <mat-datepicker #picker></mat-datepicker>
+      required>
+    <mat-hint>DD/MM/YYYY</mat-hint>
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+    <mat-error *ngFor="let validation of addPantryValidationMessages.purchase_date">
+      <mat-error class="error-message"
+                *ngIf="addToPantryForm.get('purchase_date').hasError(validation.type) && (addToPantryForm.get('purchase_date').dirty || addToPantryForm.get('purchase_date').touched)">
+        {{validation.message}}
+      </mat-error>
+    </mat-error>
   </mat-form-field>
+
   <br>
+
   <mat-form-field appearance="fill">
     <mat-label>Pantry Item Notes</mat-label>
-    <input matInput placeholder="Pantry Item Notes" data-test="notesInput" formControlName="notes" required>
+    <input matInput placeholder="Pantry Item Notes" data-test="notesInput" formControlName="notes">
+    <mat-error *ngFor="let validation of addPantryValidationMessages.notes">
+      <mat-error class="error-message"
+                *ngIf="addToPantryForm.get('notes').hasError(validation.type) && (addToPantryForm.get('notes').dirty || addToPantryForm.get('notes').touched)">
+        {{validation.message}}
+      </mat-error>
+    </mat-error>
   </mat-form-field>
+
+  <br>
+
+  <mat-form-field apearence="fill">
+    <mat-label>Quantity</mat-label>
+    <input matInput type="number" placeholder="Number of items to add" data-test="pantryQuantityInput"
+      formControlName="quantity" required>
+  </mat-form-field>
+  <mat-error *ngFor="let validation of addPantryValidationMessages.quantity">
+    <mat-error class="error-message"
+              *ngIf="addToPantryForm.get('quantity').hasError(validation.type) && (addToPantryForm.get('quantity').dirty || addToPantryForm.get('quantity').touched)">
+      {{validation.message}}
+    </mat-error>
+  </mat-error>
 </mat-dialog-content>
 
 <mat-dialog-actions>

--- a/client/src/app/products/product-list/add-product-to-pantry/add-product-to-pantry.component.ts
+++ b/client/src/app/products/product-list/add-product-to-pantry/add-product-to-pantry.component.ts
@@ -5,12 +5,15 @@ import { Product } from '../../product';
 import { PantryItem } from 'src/app/pantry/pantryItem';
 import { MAT_DIALOG_DATA, MatDialogRef, } from '@angular/material/dialog';
 
+const NOTES_CHARATER_LIMIT = 500;
+const MAX_QUANTITY_TO_ADD_AT_ONCE = 25;
+export type AddProductToPantryDialogOutput = PantryItem & {quantity: number};
+
 @Component({
   selector: 'app-add-product-to-pantry',
   templateUrl: './add-product-to-pantry.component.html',
   styleUrls: ['./add-product-to-pantry.component.scss']
 })
-
 export class AddProductToPantryComponent implements OnInit {
 
   addToPantryForm: FormGroup;
@@ -24,7 +27,12 @@ export class AddProductToPantryComponent implements OnInit {
       {type: 'minlength', message: 'Pantry item date must be 10 characters'}
     ],
     notes: [
-      {type: 'maxlength', message: 'Pantry item notes must be less than 500 characters'}
+      {type: 'maxlength', message: `Pantry item notes must be ${NOTES_CHARATER_LIMIT} characters or fewer`}
+    ],
+    quantity: [
+      {type: 'required', message: 'Quantity is requred'},
+      {type: 'max', message: `You can add at most ${MAX_QUANTITY_TO_ADD_AT_ONCE} pantry items at a time`},
+      {type: 'min', message: `You must add at least one pantry item`},
     ]
   };
 
@@ -38,14 +46,18 @@ export class AddProductToPantryComponent implements OnInit {
     this.addToPantryForm = this.fb.group({
       product: this.data._id,
 
-      purchase_date: new FormControl(new Date(),
-      Validators.compose([
+      purchase_date: new FormControl(new Date(), Validators.compose([
         Validators.required
       ])),
 
       notes: new FormControl('', Validators.compose([
-        Validators.maxLength(500)
+        Validators.maxLength(NOTES_CHARATER_LIMIT)
       ])),
+
+      quantity: new FormControl(1, Validators.compose([
+        Validators.min(1),
+        Validators.max(MAX_QUANTITY_TO_ADD_AT_ONCE),
+      ]))
     });
   }
 /* istanbul ignore next */

--- a/client/src/app/products/product-list/add-product-to-shoppinglist/add-product-to-shoppinglist.component.html
+++ b/client/src/app/products/product-list/add-product-to-shoppinglist/add-product-to-shoppinglist.component.html
@@ -3,7 +3,7 @@
 <mat-dialog-content [formGroup]="addToShoppinglistForm">
   <mat-form-field appearance="fill">
     <mat-label>Item count</mat-label>
-    <input matInput placeholder="1" data-test="countInput" formControlName="count" required>
+    <input matInput placeholder="1" data-test="shoppingListCountInput" formControlName="count" required>
   </mat-form-field>
 </mat-dialog-content>
 

--- a/client/src/app/products/product-list/product-list.component.ts
+++ b/client/src/app/products/product-list/product-list.component.ts
@@ -5,9 +5,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, } from '@angular/material/dialog';
 import { Product, ProductCategory } from '../product';
 import { ProductService } from '../product.service';
-import { Subscription } from 'rxjs';
+import { Subscription, forkJoin } from 'rxjs';
 import { PantryService } from 'src/app/pantry/pantry.service';
-import { AddProductToPantryComponent } from './add-product-to-pantry/add-product-to-pantry.component';
+import { AddProductToPantryComponent, AddProductToPantryDialogOutput } from './add-product-to-pantry/add-product-to-pantry.component';
 import { DialogDeleteComponent } from './dialog-delete/dialog-delete.component';
 import { AddProductToShoppinglistComponent } from './add-product-to-shoppinglist/add-product-to-shoppinglist.component';
 // eslint-disable-next-line max-len
@@ -135,14 +135,19 @@ export class ProductListComponent implements OnInit, OnDestroy {
   /* istanbul ignore next */
   openPantryAddDialog(givenProduct: Product) {
     const dialogRef = this.dialog.open(AddProductToPantryComponent, { data: givenProduct });
-    dialogRef.afterClosed().subscribe(result => {
-      this.pantryService.addPantryItem(result).subscribe(newPantryId => {
-        if (newPantryId) {
-          this.snackBar.open(`${givenProduct.productName} successfully added to your pantry.`,
+    dialogRef.afterClosed().subscribe((result: AddProductToPantryDialogOutput) => {
+      const { quantity, ...pantryItem } = result;
+      const allItemsToAdd = Array(quantity).fill(pantryItem);
+
+      const requests = allItemsToAdd.map(item => this.pantryService.addPantryItem(item));
+
+      forkJoin(requests).subscribe(newPantryIds => {
+        if (newPantryIds.every(id => id)) {
+          this.snackBar.open(`${quantity} ${givenProduct.productName} successfully added to your pantry.`,
             'OK', { duration: 5000 });
         }
         else {
-          this.snackBar.open('Something went wrong.  The product was not added to the pantry.',
+          this.snackBar.open(`Something went wrong.  At least one ${givenProduct.productName} was not added to the pantry.`,
             'OK', { duration: 5000 });
         }
       });


### PR DESCRIPTION
For example, this commit lets the user add 12 eggs to the pantry at
once.

Specifically, this commit adds a "quantity" field to the "Add product
to pantry" dialog, with a maximum value of 25.

Then, it makes one POST request to the pantry for each copy of the item.
These requests are executed in parallel, insofar as the browser permits.

Notes:
- The POST requests are all executed in parallel, insofar as the browser
  permits.
- On the one hand, making so many POST requests is inefficient
  in terms of network usage; but on the other hand, it was
  significantly easier to implement than changing the REST API to
  allow batch-adding of pantry items.

Closes #34 

https://user-images.githubusercontent.com/56209343/177396313-a43c1052-f8ac-4ac4-ae9e-247bdb8a235f.mov