### PR TITLE
Modify tests to allow for empty product locations

### DIFF
--- a/client/src/app/products/product-form/product-form-validation.spec.ts
+++ b/client/src/app/products/product-form/product-form-validation.spec.ts
@@ -284,9 +284,9 @@ for (const mode of possibleModes) {
         locationControl = productForm.controls.location;
       });
 
-      it('should not allow empty location', () => {
+      it('should allow empty location', () => {
         locationControl.setValue('');
-        expect(locationControl.valid).toBeFalsy();
+        expect(locationControl.valid).toBeTruthy();
       });
 
       it('should be fine with "location of item"', () => {

--- a/client/src/app/products/product-form/product-form.component.html
+++ b/client/src/app/products/product-form/product-form.component.html
@@ -82,7 +82,7 @@
         <mat-form-field>
           <mat-label>Product Location</mat-label>
           <input matInput placeholder="Product Location" formControlName="location"
-                  required data-test="productLocationInput">
+                  data-test="productLocationInput">
           <mat-error *ngFor="let validation of productValidationMessages.location">
             <mat-error class="error-message" data-test="locationError"
                       *ngIf="productForm.get('location').hasError(validation.type) && (productForm.get('location').dirty || productForm.get('location').touched)">

--- a/client/src/app/products/product-form/product-form.component.ts
+++ b/client/src/app/products/product-form/product-form.component.ts
@@ -58,7 +58,6 @@ export class ProductFormComponent implements OnInit, OnDestroy {
       { type: 'maxlength', message: 'Product store must be at less than 100 characters' }
     ],
     location: [
-      { type: 'required', message: 'Must provide a location'},
       { type: 'minlength', message: 'Product location must be at least 1 character' },
       { type: 'maxlength', message: 'Product location must be at less than 100 characters' }
     ],
@@ -121,7 +120,7 @@ export class ProductFormComponent implements OnInit, OnDestroy {
         Validators.required, Validators.minLength(1), Validators.maxLength(100),
       ])),
       location: new FormControl(this.getProductValueOrEmptyString('location'), Validators.compose([
-        Validators.required, Validators.minLength(1), Validators.maxLength(100),
+        Validators.minLength(1), Validators.maxLength(100),
       ])),
       notes: new FormControl(this.getProductValueOrEmptyString('notes'), Validators.compose([
         Validators.minLength(1), Validators.maxLength(2000),

--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -229,8 +229,7 @@ public class ProductController {
         .check(product -> product.category != null && product.category.length() > 0,
             "Product must have a non-empty category")
         .check(product -> product.store != null && product.store.length() > 0, "Product must have a non-empty store")
-        .check(product -> product.location != null && product.location.length() > 0,
-            "Product must have a non-empty location")
+        .check(product -> product.location != null, "Product location cannot be null")
         // .check(product -> product.notes != null && product.notes.length() > 0, "Product notes cannot be null")
         // .check(product -> product.tags != null && product.tags.size() >= 0, "Product
         // tags cannot be null")

--- a/server/src/test/java/umm3601/product/ProductControllerValidateProductSpec.java
+++ b/server/src/test/java/umm3601/product/ProductControllerValidateProductSpec.java
@@ -476,10 +476,6 @@ public class ProductControllerValidateProductSpec {
 
     assertEquals("", addedProduct.getString("location"));
 
-    /* assertThrows(ValidationException.class, () -> {
-      productController.addNewProduct(ctx);
-    }); */
-
   }
 
 }

--- a/server/src/test/java/umm3601/product/ProductControllerValidateProductSpec.java
+++ b/server/src/test/java/umm3601/product/ProductControllerValidateProductSpec.java
@@ -368,7 +368,6 @@ public class ProductControllerValidateProductSpec {
       productController.addNewProduct(ctx);
     });
   }
-
   @Test
   public void addNullStoreProduct() throws IOException {
     String testNewProduct = "{"
@@ -464,9 +463,23 @@ public class ProductControllerValidateProductSpec {
 
     Context ctx = mockContext("api/products");
 
-    assertThrows(ValidationException.class, () -> {
+    productController.addNewProduct(ctx);
+    String result = ctx.resultString();
+    String id = javalinJackson.fromJsonString(result, ObjectNode.class).get("id").asText();
+
+    assertEquals(HttpURLConnection.HTTP_CREATED, mockRes.getStatus());
+
+    assertNotEquals("", id);
+    assertEquals(1, db.getCollection("products").countDocuments(eq("_id", new ObjectId(id))));
+
+    Document addedProduct = db.getCollection("products").find(eq("_id", new ObjectId(id))).first();
+
+    assertEquals("", addedProduct.getString("location"));
+
+    /* assertThrows(ValidationException.class, () -> {
       productController.addNewProduct(ctx);
-    });
+    }); */
+
   }
 
 }


### PR DESCRIPTION
Closes #16. This removes all validation that required that a product have a location field, as well as changes the tests to verify that a product can have an empty location. (Represented as ""–a null location still throws a validation exception).